### PR TITLE
TEST

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironment.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironment.java
@@ -235,7 +235,7 @@ class ConfigDataEnvironment {
 		MutablePropertySources propertySources = this.environment.getPropertySources();
 		this.logger.trace("Applying config data environment contributions");
 		for (ConfigDataEnvironmentContributor contributor : contributors) {
-			if (contributor.getKind() == ConfigDataEnvironmentContributor.Kind.IMPORTED
+			if (contributor.getKind() == ConfigDataEnvironmentContributor.Kind.BOUND_IMPORT
 					&& contributor.getPropertySource() != null) {
 				if (!contributor.isActive(activationContext)) {
 					this.logger.trace(LogMessage.format("Skipping inactive property source '%s'",

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributorPlaceholdersResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributorPlaceholdersResolverTests.java
@@ -122,7 +122,7 @@ class ConfigDataEnvironmentContributorPlaceholdersResolverTests {
 		private final boolean active;
 
 		protected TestConfigDataEnvironmentContributor(PropertySource<?> propertySource, boolean active) {
-			super(Kind.ROOT, null, propertySource, null, null, null);
+			super(Kind.ROOT, null, propertySource, null, null, false, null);
 			this.active = active;
 		}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributorTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.boot.context.config.ConfigDataEnvironmentContributor.ImportPhase;
 import org.springframework.boot.context.config.ConfigDataEnvironmentContributor.Kind;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.mock.env.MockPropertySource;
 
@@ -63,8 +64,7 @@ class ConfigDataEnvironmentContributorTests {
 		MockPropertySource propertySource = new MockPropertySource();
 		propertySource.setProperty("spring.config.activate.on-cloud-platform", "kubernetes");
 		ConfigData configData = new ConfigData(Collections.singleton(propertySource));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(null, configData, 0,
-				this.activationContext);
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(null, configData, 0);
 		assertThat(contributor.isActive(this.activationContext)).isTrue();
 	}
 
@@ -73,8 +73,7 @@ class ConfigDataEnvironmentContributorTests {
 		MockPropertySource propertySource = new MockPropertySource();
 		propertySource.setProperty("spring.config.activate.on-cloud-platform", "heroku");
 		ConfigData configData = new ConfigData(Collections.singleton(propertySource));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(null, configData, 0,
-				this.activationContext);
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(null, configData, 0);
 		assertThat(contributor.isActive(this.activationContext)).isFalse();
 	}
 
@@ -82,8 +81,8 @@ class ConfigDataEnvironmentContributorTests {
 	void getLocationReturnsLocation() {
 		ConfigData configData = new ConfigData(Collections.singleton(new MockPropertySource()));
 		ConfigDataLocation location = mock(ConfigDataLocation.class);
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(location, configData,
-				0, this.activationContext);
+		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofUnboundImport(location,
+				configData, 0);
 		assertThat(contributor.getLocation()).isSameAs(location);
 	}
 
@@ -99,8 +98,8 @@ class ConfigDataEnvironmentContributorTests {
 		MockPropertySource propertySource = new MockPropertySource();
 		propertySource.setProperty("spring", "boot");
 		ConfigData configData = new ConfigData(Collections.singleton(propertySource));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(null, configData, 0,
-				this.activationContext);
+		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofUnboundImport(null,
+				configData, 0);
 		assertThat(contributor.getConfigurationPropertySource()
 				.getConfigurationProperty(ConfigurationPropertyName.of("spring")).getValue()).isEqualTo("boot");
 	}
@@ -108,8 +107,7 @@ class ConfigDataEnvironmentContributorTests {
 	@Test
 	void getImportsWhenPropertiesIsNullReturnsEmptyList() {
 		ConfigData configData = new ConfigData(Collections.singleton(new MockPropertySource()));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(null, configData, 0,
-				this.activationContext);
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(null, configData, 0);
 		assertThat(contributor.getImports()).isEmpty();
 	}
 
@@ -118,16 +116,14 @@ class ConfigDataEnvironmentContributorTests {
 		MockPropertySource propertySource = new MockPropertySource();
 		propertySource.setProperty("spring.config.import", "spring,boot");
 		ConfigData configData = new ConfigData(Collections.singleton(propertySource));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(null, configData, 0,
-				this.activationContext);
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(null, configData, 0);
 		assertThat(contributor.getImports()).containsExactly("spring", "boot");
 	}
 
 	@Test
 	void hasUnprocessedImportsWhenNoImportsReturnsFalse() {
 		ConfigData configData = new ConfigData(Collections.singleton(new MockPropertySource()));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(null, configData, 0,
-				this.activationContext);
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(null, configData, 0);
 		assertThat(contributor.hasUnprocessedImports(ImportPhase.BEFORE_PROFILE_ACTIVATION)).isFalse();
 	}
 
@@ -136,8 +132,7 @@ class ConfigDataEnvironmentContributorTests {
 		MockPropertySource propertySource = new MockPropertySource();
 		propertySource.setProperty("spring.config.import", "springboot");
 		ConfigData configData = new ConfigData(Collections.singleton(propertySource));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(null, configData, 0,
-				this.activationContext);
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(null, configData, 0);
 		assertThat(contributor.hasUnprocessedImports(ImportPhase.BEFORE_PROFILE_ACTIVATION)).isTrue();
 	}
 
@@ -146,11 +141,9 @@ class ConfigDataEnvironmentContributorTests {
 		MockPropertySource propertySource = new MockPropertySource();
 		propertySource.setProperty("spring.config.import", "springboot");
 		ConfigData configData = new ConfigData(Collections.singleton(propertySource));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(null, configData, 0,
-				this.activationContext);
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(null, configData, 0);
 		ConfigData childConfigData = new ConfigData(Collections.singleton(new MockPropertySource()));
-		ConfigDataEnvironmentContributor childContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				childConfigData, 0, this.activationContext);
+		ConfigDataEnvironmentContributor childContributor = createBoundContributor(null, childConfigData, 0);
 		ConfigDataEnvironmentContributor withChildren = contributor.withChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION,
 				Collections.singletonList(childContributor));
 		assertThat(withChildren.hasUnprocessedImports(ImportPhase.BEFORE_PROFILE_ACTIVATION)).isFalse();
@@ -160,8 +153,7 @@ class ConfigDataEnvironmentContributorTests {
 	@Test
 	void getChildrenWhenHasNoChildrenReturnsEmptyList() {
 		ConfigData configData = new ConfigData(Collections.singleton(new MockPropertySource()));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(null, configData, 0,
-				this.activationContext);
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(null, configData, 0);
 		assertThat(contributor.getChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION)).isEmpty();
 		assertThat(contributor.getChildren(ImportPhase.AFTER_PROFILE_ACTIVATION)).isEmpty();
 	}
@@ -171,11 +163,9 @@ class ConfigDataEnvironmentContributorTests {
 		MockPropertySource propertySource = new MockPropertySource();
 		propertySource.setProperty("spring.config.import", "springboot");
 		ConfigData configData = new ConfigData(Collections.singleton(propertySource));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(null, configData, 0,
-				this.activationContext);
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(null, configData, 0);
 		ConfigData childConfigData = new ConfigData(Collections.singleton(new MockPropertySource()));
-		ConfigDataEnvironmentContributor childContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				childConfigData, 0, this.activationContext);
+		ConfigDataEnvironmentContributor childContributor = createBoundContributor(null, childConfigData, 0);
 		ConfigDataEnvironmentContributor withChildren = contributor.withChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION,
 				Collections.singletonList(childContributor));
 		assertThat(withChildren.getChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION)).containsExactly(childContributor);
@@ -184,35 +174,36 @@ class ConfigDataEnvironmentContributorTests {
 
 	@Test
 	void streamReturnsStream() {
-		ConfigDataEnvironmentContributor contributor = createContributor("a");
+		ConfigDataEnvironmentContributor contributor = createBoundContributor("a");
 		Stream<String> stream = contributor.stream().map(this::getLocationName);
 		assertThat(stream).containsExactly("a");
 	}
 
 	@Test
 	void iteratorWhenSingleContributorReturnsSingletonIterator() {
-		ConfigDataEnvironmentContributor contributor = createContributor("a");
+		ConfigDataEnvironmentContributor contributor = createBoundContributor("a");
 		assertThat(asLocationsList(contributor.iterator())).containsExactly("a");
 	}
 
 	@Test
 	void iteratorWhenTypicalStructureReturnsCorrectlyOrderedIterator() {
-		ConfigDataEnvironmentContributor fileApplication = createContributor("file:application.properties");
-		ConfigDataEnvironmentContributor fileProfile = createContributor("file:application-profile.properties");
-		ConfigDataEnvironmentContributor fileImports = createContributor("file:./");
+		ConfigDataEnvironmentContributor fileApplication = createBoundContributor("file:application.properties");
+		ConfigDataEnvironmentContributor fileProfile = createBoundContributor("file:application-profile.properties");
+		ConfigDataEnvironmentContributor fileImports = createBoundContributor("file:./");
 		fileImports = fileImports.withChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION,
 				Collections.singletonList(fileApplication));
 		fileImports = fileImports.withChildren(ImportPhase.AFTER_PROFILE_ACTIVATION,
 				Collections.singletonList(fileProfile));
-		ConfigDataEnvironmentContributor classpathApplication = createContributor("classpath:application.properties");
-		ConfigDataEnvironmentContributor classpathProfile = createContributor(
+		ConfigDataEnvironmentContributor classpathApplication = createBoundContributor(
+				"classpath:application.properties");
+		ConfigDataEnvironmentContributor classpathProfile = createBoundContributor(
 				"classpath:application-profile.properties");
-		ConfigDataEnvironmentContributor classpathImports = createContributor("classpath:/");
+		ConfigDataEnvironmentContributor classpathImports = createBoundContributor("classpath:/");
 		classpathImports = classpathImports.withChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION,
 				Arrays.asList(classpathApplication));
 		classpathImports = classpathImports.withChildren(ImportPhase.AFTER_PROFILE_ACTIVATION,
 				Arrays.asList(classpathProfile));
-		ConfigDataEnvironmentContributor root = createContributor("root");
+		ConfigDataEnvironmentContributor root = createBoundContributor("root");
 		root = root.withChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION, Arrays.asList(fileImports, classpathImports));
 		assertThat(asLocationsList(root.iterator())).containsExactly("file:application-profile.properties",
 				"file:application.properties", "file:./", "classpath:application-profile.properties",
@@ -221,8 +212,8 @@ class ConfigDataEnvironmentContributorTests {
 
 	@Test
 	void withChildrenReturnsNewInstanceWithChildren() {
-		ConfigDataEnvironmentContributor root = createContributor("root");
-		ConfigDataEnvironmentContributor child = createContributor("child");
+		ConfigDataEnvironmentContributor root = createBoundContributor("root");
+		ConfigDataEnvironmentContributor child = createBoundContributor("child");
 		ConfigDataEnvironmentContributor withChildren = root.withChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION,
 				Collections.singletonList(child));
 		assertThat(root.getChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION)).isEmpty();
@@ -231,12 +222,12 @@ class ConfigDataEnvironmentContributorTests {
 
 	@Test
 	void withReplacementReplacesChild() {
-		ConfigDataEnvironmentContributor root = createContributor("root");
-		ConfigDataEnvironmentContributor child = createContributor("child");
-		ConfigDataEnvironmentContributor grandchild = createContributor("grandchild");
+		ConfigDataEnvironmentContributor root = createBoundContributor("root");
+		ConfigDataEnvironmentContributor child = createBoundContributor("child");
+		ConfigDataEnvironmentContributor grandchild = createBoundContributor("grandchild");
 		child = child.withChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION, Collections.singletonList(grandchild));
 		root = root.withChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION, Collections.singletonList(child));
-		ConfigDataEnvironmentContributor updated = createContributor("updated");
+		ConfigDataEnvironmentContributor updated = createBoundContributor("updated");
 		ConfigDataEnvironmentContributor withReplacement = root.withReplacement(grandchild, updated);
 		assertThat(asLocationsList(root.iterator())).containsExactly("grandchild", "child", "root");
 		assertThat(asLocationsList(withReplacement.iterator())).containsExactly("updated", "child", "root");
@@ -244,8 +235,8 @@ class ConfigDataEnvironmentContributorTests {
 
 	@Test
 	void ofCreatesRootContributor() {
-		ConfigDataEnvironmentContributor one = createContributor("one");
-		ConfigDataEnvironmentContributor two = createContributor("two");
+		ConfigDataEnvironmentContributor one = createBoundContributor("one");
+		ConfigDataEnvironmentContributor two = createBoundContributor("two");
 		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.of(Arrays.asList(one, two));
 		assertThat(contributor.getKind()).isEqualTo(Kind.ROOT);
 		assertThat(contributor.getLocation()).isNull();
@@ -284,31 +275,14 @@ class ConfigDataEnvironmentContributorTests {
 	}
 
 	@Test
-	void ofImportedCreatesImportedContributor() {
+	void ofUnboundImportCreatesImportedContributor() {
 		TestLocation location = new TestLocation("test");
 		MockPropertySource propertySource = new MockPropertySource();
 		propertySource.setProperty("spring.config.import", "test");
 		ConfigData configData = new ConfigData(Collections.singleton(propertySource));
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(location, configData,
-				0, this.activationContext);
-		assertThat(contributor.getKind()).isEqualTo(Kind.IMPORTED);
-		assertThat(contributor.getLocation()).isSameAs(location);
-		assertThat(contributor.getImports()).containsExactly("test");
-		assertThat(contributor.isActive(this.activationContext)).isTrue();
-		assertThat(contributor.getPropertySource()).isEqualTo(propertySource);
-		assertThat(contributor.getConfigurationPropertySource()).isNotNull();
-		assertThat(contributor.getChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION)).isEmpty();
-	}
-
-	@Test
-	void ofImportedWhenConfigDataHasIgnoreImportsOptionsCreatesImportedContributorWithoutImports() {
-		TestLocation location = new TestLocation("test");
-		MockPropertySource propertySource = new MockPropertySource();
-		propertySource.setProperty("spring.config.import", "test");
-		ConfigData configData = new ConfigData(Collections.singleton(propertySource), ConfigData.Option.IGNORE_IMPORTS);
-		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofImported(location, configData,
-				0, this.activationContext);
-		assertThat(contributor.getKind()).isEqualTo(Kind.IMPORTED);
+		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofUnboundImport(location,
+				configData, 0);
+		assertThat(contributor.getKind()).isEqualTo(Kind.UNBOUND_IMPORT);
 		assertThat(contributor.getLocation()).isSameAs(location);
 		assertThat(contributor.getImports()).isEmpty();
 		assertThat(contributor.isActive(this.activationContext)).isTrue();
@@ -318,17 +292,56 @@ class ConfigDataEnvironmentContributorTests {
 	}
 
 	@Test
-	void ofImportedWhenHasUseLegacyPropertyThrowsException() {
+	void bindCreatesImportedContributor() {
+		TestLocation location = new TestLocation("test");
 		MockPropertySource propertySource = new MockPropertySource();
-		propertySource.setProperty("spring.config.use-legacy-processing", "true");
-		assertThatExceptionOfType(UseLegacyConfigProcessingException.class)
-				.isThrownBy(() -> ConfigDataEnvironmentContributor.ofImported(null,
-						new ConfigData(Collections.singleton(propertySource)), 0, this.activationContext));
+		propertySource.setProperty("spring.config.import", "test");
+		ConfigData configData = new ConfigData(Collections.singleton(propertySource));
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(location, configData, 0);
+		assertThat(contributor.getKind()).isEqualTo(Kind.BOUND_IMPORT);
+		assertThat(contributor.getLocation()).isSameAs(location);
+		assertThat(contributor.getImports()).containsExactly("test");
+		assertThat(contributor.isActive(this.activationContext)).isTrue();
+		assertThat(contributor.getPropertySource()).isEqualTo(propertySource);
+		assertThat(contributor.getConfigurationPropertySource()).isNotNull();
+		assertThat(contributor.getChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION)).isEmpty();
 	}
 
-	private ConfigDataEnvironmentContributor createContributor(String location) {
-		return ConfigDataEnvironmentContributor.ofImported(new TestLocation(location),
-				new ConfigData(Collections.singleton(new MockPropertySource())), 0, this.activationContext);
+	@Test
+	void bindWhenConfigDataHasIgnoreImportsOptionsCreatesImportedContributorWithoutImports() {
+		TestLocation location = new TestLocation("test");
+		MockPropertySource propertySource = new MockPropertySource();
+		propertySource.setProperty("spring.config.import", "test");
+		ConfigData configData = new ConfigData(Collections.singleton(propertySource), ConfigData.Option.IGNORE_IMPORTS);
+		ConfigDataEnvironmentContributor contributor = createBoundContributor(location, configData, 0);
+		assertThat(contributor.getKind()).isEqualTo(Kind.BOUND_IMPORT);
+		assertThat(contributor.getLocation()).isSameAs(location);
+		assertThat(contributor.getImports()).isEmpty();
+		assertThat(contributor.isActive(this.activationContext)).isTrue();
+		assertThat(contributor.getPropertySource()).isEqualTo(propertySource);
+		assertThat(contributor.getConfigurationPropertySource()).isNotNull();
+		assertThat(contributor.getChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION)).isEmpty();
+	}
+
+	@Test
+	void bindWhenHasUseLegacyPropertyThrowsException() {
+		MockPropertySource propertySource = new MockPropertySource();
+		propertySource.setProperty("spring.config.use-legacy-processing", "true");
+		assertThatExceptionOfType(UseLegacyConfigProcessingException.class).isThrownBy(
+				() -> createBoundContributor(null, new ConfigData(Collections.singleton(propertySource)), 0));
+	}
+
+	private ConfigDataEnvironmentContributor createBoundContributor(String location) {
+		return createBoundContributor(new TestLocation(location),
+				new ConfigData(Collections.singleton(new MockPropertySource())), 0);
+	}
+
+	private ConfigDataEnvironmentContributor createBoundContributor(ConfigDataLocation location, ConfigData configData,
+			int propertySourceIndex) {
+		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofUnboundImport(location,
+				configData, propertySourceIndex);
+		Binder binder = new Binder(contributor.getConfigurationPropertySource());
+		return contributor.withBoundProperties(binder);
 	}
 
 	private List<String> asLocationsList(Iterator<ConfigDataEnvironmentContributor> iterator) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributorsTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributorsTests.java
@@ -268,10 +268,8 @@ class ConfigDataEnvironmentContributorsTests {
 		MockPropertySource secondPropertySource = new MockPropertySource();
 		secondPropertySource.setProperty("test", "two");
 		ConfigData configData = new ConfigData(Arrays.asList(firstPropertySource, secondPropertySource));
-		ConfigDataEnvironmentContributor firstContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 0, this.activationContext);
-		ConfigDataEnvironmentContributor secondContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 1, this.activationContext);
+		ConfigDataEnvironmentContributor firstContributor = createBoundImportContributor(configData, 0);
+		ConfigDataEnvironmentContributor secondContributor = createBoundImportContributor(configData, 1);
 		ConfigDataEnvironmentContributors contributors = new ConfigDataEnvironmentContributors(this.logFactory,
 				this.bootstrapRegistry, Arrays.asList(firstContributor, secondContributor));
 		Binder binder = contributors.getBinder(this.activationContext);
@@ -286,10 +284,8 @@ class ConfigDataEnvironmentContributorsTests {
 		MockPropertySource secondPropertySource = new MockPropertySource();
 		secondPropertySource.setProperty("test", "two");
 		ConfigData configData = new ConfigData(Arrays.asList(firstPropertySource, secondPropertySource));
-		ConfigDataEnvironmentContributor firstContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 0, this.activationContext);
-		ConfigDataEnvironmentContributor secondContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 1, this.activationContext);
+		ConfigDataEnvironmentContributor firstContributor = createBoundImportContributor(configData, 0);
+		ConfigDataEnvironmentContributor secondContributor = createBoundImportContributor(configData, 1);
 		ConfigDataEnvironmentContributors contributors = new ConfigDataEnvironmentContributors(this.logFactory,
 				this.bootstrapRegistry, Arrays.asList(firstContributor, secondContributor));
 		Binder binder = contributors.getBinder(this.activationContext);
@@ -317,10 +313,8 @@ class ConfigDataEnvironmentContributorsTests {
 		secondPropertySource.setProperty("other", "two");
 		secondPropertySource.setProperty("test", "${other}");
 		ConfigData configData = new ConfigData(Arrays.asList(firstPropertySource, secondPropertySource));
-		ConfigDataEnvironmentContributor firstContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 0, this.activationContext);
-		ConfigDataEnvironmentContributor secondContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 1, this.activationContext);
+		ConfigDataEnvironmentContributor firstContributor = createBoundImportContributor(configData, 0);
+		ConfigDataEnvironmentContributor secondContributor = createBoundImportContributor(configData, 1);
 		ConfigDataEnvironmentContributors contributors = new ConfigDataEnvironmentContributors(this.logFactory,
 				this.bootstrapRegistry, Arrays.asList(firstContributor, secondContributor));
 		Binder binder = contributors.getBinder(this.activationContext);
@@ -335,10 +329,8 @@ class ConfigDataEnvironmentContributorsTests {
 		MockPropertySource secondPropertySource = new MockPropertySource();
 		secondPropertySource.setProperty("test", "two");
 		ConfigData configData = new ConfigData(Arrays.asList(firstPropertySource, secondPropertySource));
-		ConfigDataEnvironmentContributor firstContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 0, this.activationContext);
-		ConfigDataEnvironmentContributor secondContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 1, this.activationContext);
+		ConfigDataEnvironmentContributor firstContributor = createBoundImportContributor(configData, 0);
+		ConfigDataEnvironmentContributor secondContributor = createBoundImportContributor(configData, 1);
 		ConfigDataEnvironmentContributors contributors = new ConfigDataEnvironmentContributors(this.logFactory,
 				this.bootstrapRegistry, Arrays.asList(firstContributor, secondContributor));
 		Binder binder = contributors.getBinder(this.activationContext, BinderOption.FAIL_ON_BIND_TO_INACTIVE_SOURCE);
@@ -354,10 +346,8 @@ class ConfigDataEnvironmentContributorsTests {
 		secondPropertySource.setProperty("spring.config.activate.on-profile", "production");
 		secondPropertySource.setProperty("test", "two");
 		ConfigData configData = new ConfigData(Arrays.asList(firstPropertySource, secondPropertySource));
-		ConfigDataEnvironmentContributor firstContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 0, this.activationContext);
-		ConfigDataEnvironmentContributor secondContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 1, this.activationContext);
+		ConfigDataEnvironmentContributor firstContributor = createBoundImportContributor(configData, 0);
+		ConfigDataEnvironmentContributor secondContributor = createBoundImportContributor(configData, 1);
 		ConfigDataEnvironmentContributors contributors = new ConfigDataEnvironmentContributors(this.logFactory,
 				this.bootstrapRegistry, Arrays.asList(firstContributor, secondContributor));
 		Binder binder = contributors.getBinder(this.activationContext, BinderOption.FAIL_ON_BIND_TO_INACTIVE_SOURCE);
@@ -374,15 +364,21 @@ class ConfigDataEnvironmentContributorsTests {
 		secondPropertySource.setProperty("test", "${other}");
 		secondPropertySource.setProperty("other", "one");
 		ConfigData configData = new ConfigData(Arrays.asList(firstPropertySource, secondPropertySource));
-		ConfigDataEnvironmentContributor firstContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 0, this.activationContext);
-		ConfigDataEnvironmentContributor secondContributor = ConfigDataEnvironmentContributor.ofImported(null,
-				configData, 1, this.activationContext);
+		ConfigDataEnvironmentContributor firstContributor = createBoundImportContributor(configData, 0);
+		ConfigDataEnvironmentContributor secondContributor = createBoundImportContributor(configData, 1);
 		ConfigDataEnvironmentContributors contributors = new ConfigDataEnvironmentContributors(this.logFactory,
 				this.bootstrapRegistry, Arrays.asList(firstContributor, secondContributor));
 		Binder binder = contributors.getBinder(this.activationContext, BinderOption.FAIL_ON_BIND_TO_INACTIVE_SOURCE);
 		assertThatExceptionOfType(BindException.class).isThrownBy(() -> binder.bind("test", String.class))
 				.satisfies((ex) -> assertThat(ex.getCause()).isInstanceOf(InactiveConfigDataAccessException.class));
+	}
+
+	private ConfigDataEnvironmentContributor createBoundImportContributor(ConfigData configData,
+			int propertySourceIndex) {
+		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofUnboundImport(null,
+				configData, propertySourceIndex);
+		Binder binder = new Binder(contributor.getConfigurationPropertySource());
+		return contributor.withBoundProperties(binder);
 	}
 
 	private static class TestConfigDataLocation extends ConfigDataLocation {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.context.properties.bind.BindException;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -512,6 +513,27 @@ class ConfigDataEnvironmentPostProcessorIntegrationTests {
 	void runWhenUsingInvalidPropertyThrowsException() {
 		assertThatExceptionOfType(InvalidConfigDataPropertyException.class).isThrownBy(
 				() -> this.application.run("--spring.config.location=classpath:invalidproperty.properties"));
+	}
+
+	@Test
+	void runWhenImportUsesPlaceholder() {
+		ConfigurableApplicationContext context = this.application
+				.run("--spring.config.location=classpath:application-import-with-placeholder.properties");
+		assertThat(context.getEnvironment().getProperty("my.value")).isEqualTo("iwasimported");
+	}
+
+	@Test
+	void runWhenImportFromEarlierDocumentUsesPlaceholder() {
+		ConfigurableApplicationContext context = this.application
+				.run("--spring.config.location=classpath:application-import-with-placeholder-in-document.properties");
+		assertThat(context.getEnvironment().getProperty("my.value")).isEqualTo("iwasimported");
+	}
+
+	@Test
+	void runWhenHasPropertyInProfileDocumentThrowsException() {
+		assertThatExceptionOfType(BindException.class).isThrownBy(() -> this.application.run(
+				"--spring.config.location=classpath:application-import-with-placeholder-in-profile-document.properties"))
+				.withCauseInstanceOf(InactiveConfigDataAccessException.class);
 	}
 
 	private Condition<ConfigurableEnvironment> matchingPropertySource(final String sourceName) {

--- a/spring-boot-project/spring-boot/src/test/resources/application-import-with-placeholder-imported.properties
+++ b/spring-boot-project/spring-boot/src/test/resources/application-import-with-placeholder-imported.properties
@@ -1,0 +1,1 @@
+my.value=iwasimported

--- a/spring-boot-project/spring-boot/src/test/resources/application-import-with-placeholder-in-document.properties
+++ b/spring-boot-project/spring-boot/src/test/resources/application-import-with-placeholder-in-document.properties
@@ -1,0 +1,3 @@
+my.import=application-import-with-placeholder-imported
+#---
+spring.config.import=classpath:${my.import}.properties

--- a/spring-boot-project/spring-boot/src/test/resources/application-import-with-placeholder-in-profile-document.properties
+++ b/spring-boot-project/spring-boot/src/test/resources/application-import-with-placeholder-in-profile-document.properties
@@ -1,0 +1,6 @@
+my.import=application-import-with-placeholder-imported
+#---
+spring.config.import=classpath:${my.import}.properties
+#---
+my.import=badbadbad
+spring.config.activate.on-profile=missing

--- a/spring-boot-project/spring-boot/src/test/resources/application-import-with-placeholder.properties
+++ b/spring-boot-project/spring-boot/src/test/resources/application-import-with-placeholder.properties
@@ -1,0 +1,2 @@
+my.import=application-import-with-placeholder-imported
+spring.config.import=classpath:${my.import}.properties


### PR DESCRIPTION
Allow `${..}` property placeholders to be used in `spring.config.import`
properties. Prior to this commit, placeholders were not resolved when
binding the `ConfigDataProperty` instance. Furthermore, binding happened
too early for all placeholders to be resolved correctly. The
`ConfigDataEnvironmentContributor` class now has two states for imported
contributors, `UNBOUND_IMPORT` has the initial unbound state and is
eventually replaced with a `BOUND_IMPORT`.

Closes gh-23020

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://pivotal.io/security to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
